### PR TITLE
Creating an interval that should exist for the lifetime of the Twitter page.

### DIFF
--- a/public/js/replace-trending.js
+++ b/public/js/replace-trending.js
@@ -1,19 +1,30 @@
 function frogit() {
-  let theadlines = document.getElementsByTagName("h1");
-  let searchText = "Trending now";
-  let trendingHeadline;
+  const searchText = "Trending now";
 
-  for (let i = 0; i < theadlines.length; i++) {
-    if (theadlines[i].textContent == searchText) {
-      trendingHeadline = theadlines[i];
-      break;
+  // Twitter highjacks a lot of the browser's functon on its page, so listening on events is proving fruitless. An interval was kind of a last resort, but it works.
+  // This only works so long as the page does not totally reload at the BOM, or window layer. Currently the Home link is a full BOM load.
+  setInterval(function(){
+    if(location.href !== frogit.href){
+      const theadlines = document.getElementsByTagName("h1");
+      let trendingHeadline;
+      
+      for (let i = 0; i < theadlines.length; i++) {
+        if (theadlines[i].textContent == searchText) {
+          trendingHeadline = theadlines[i];
+          break;
+        }
+      }
+
+      if(trendingHeadline) {
+        // href being the trip wire, we want to wait for the actual trending headline to exist before we cause the interval to short circuit.
+        frogit.href = location.href;
+        const oldTrending = trendingHeadline.nextSibling;
+        const frogs = document.createElement('div');
+        frogs.innerHTML = '<p style="color:white; font-family:helvetica; text-align:center;">Have a nice day :)</p>';
+        oldTrending.parentNode.replaceChild(frogs, oldTrending);
+      }
     }
-  }
-
-  let oldTrending = trendingHeadline.nextSibling;
-  const frogs = document.createElement('div');
-  frogs.innerHTML = '<p style="color:white; font-family:helvetica; text-align:center;">Have a nice day :)</p>';
-  oldTrending.parentNode.replaceChild(frogs, oldTrending);
+  }, 10);
 };
 
 frogit();


### PR DESCRIPTION
* Modified lets into const. Key difference being that the references are immutable and they are not changing within their respective scopes.
* Added an interval to check every 10ms for a location change. This is a key navigation value in twitter. The frogit function will have a respective variable. This isn't common practice, but it felt right in this case.